### PR TITLE
Fix: save & restore state for nested encode & decode calls

### DIFF
--- a/src/decoding.ts
+++ b/src/decoding.ts
@@ -317,15 +317,21 @@ function takeGeneric(): unknown {
  * @param data The buffer to decode from.
  */
 export function decode<T = unknown>(data: ArrayBuffer | Uint8Array): T {
+    // Store previous state in case decode is called while decoding
+    const prevBuffer = buffer
+    const prevView = view
+    const prevOffset = offset
+
     buffer = data instanceof Uint8Array ? data : new Uint8Array(data);
     view = new DataView(buffer.buffer, buffer.byteOffset);
     offset = 0;
 
     const result = takeGeneric() as T;
 
-    // Don't impede garbage collection!
-    buffer = undefined as any;
-    view = undefined as any;
+    // Revert state in case decode is called while decoding
+    buffer = prevBuffer
+    view = prevView
+    offset = prevOffset
 
     return result;
 }

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -371,5 +371,17 @@ export function encodeView(value: any, reserve = 0): Uint8Array {
  *                encoding process.
  */
 export function encode(value: any, reserve = 0): Uint8Array {
-    return encodeView(value, reserve).slice();
+    // Store previous state in case encode is called while encoding
+    const prevBuffer = buffer
+    const prevView = view
+    const prevOffset = offset
+
+    const result = encodeView(value, reserve).slice();
+
+    // Revert state in case encode was called while encoding
+    buffer = prevBuffer
+    view = prevView
+    offset = prevOffset
+
+    return result
 }

--- a/src/general.test.ts
+++ b/src/general.test.ts
@@ -1,5 +1,5 @@
 import { it, expect } from 'vitest';
-import { encode, decode, DECODE_OPTS } from '.';
+import { encode, decode, DECODE_OPTS, registerExtension } from '.';
 
 it('Encode+decode produces the original input', () => {
     const data = {
@@ -85,5 +85,34 @@ it("Respects 'nilValue' and omits undefined map values", () => {
 
     DECODE_OPTS.nilValue = origNilValue;
 });
+
+it("Handles nested calls to encode and decode", () => {
+    class CustomA {
+        constructor(readonly valueA: CustomB) {}
+    }
+    class CustomB {
+        constructor(readonly valueB: number) {}
+    }
+
+    registerExtension(
+        1,
+        CustomA,
+        (custom) => encode(custom.valueA),
+        (buffer) => new CustomA(decode(buffer))
+    )
+    registerExtension(
+        2,
+        CustomB,
+        (custom) => new Uint8Array([custom.valueB]),
+        (buffer) => new CustomB(buffer[0])
+    )
+
+    const data = new CustomA(new CustomB(0))
+    const output = decode(encode(data)) as any
+
+    expect(output).toBeInstanceOf(CustomA)
+    expect(output.valueA).toBeInstanceOf(CustomB)
+    expect(output.valueA.valueB).toStrictEqual(0)
+})
 
 // TODO: more tests, refine tests


### PR DESCRIPTION
Hey! Thanks a lot for this library! 

I am using lots of extensions with msgpack and some of them have calls to `decode` (while a value is already being decoded), which I think currently fails in some cases with this library.

I'm hoping this solution logically makes sense?