### PR TITLE
Add CommonJS build

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "vitest": "^1.4.0"
   },
   "type": "module",
-  "main": "dist/index.mjs",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "/dist/**/*"

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -7,8 +7,8 @@ import dts from 'vite-plugin-dts';
 export default defineConfig({
     build: {
         lib: {
-            formats: ['es'],
-            fileName: () => 'index.mjs', // Need function otherwise it produces 'index.mjs.js'!
+            formats: ['es', 'cjs'],
+            fileName: (format) => format === 'cjs' ? 'index.cjs' : 'index.mjs', // Need function otherwise it produces 'index.mjs.js'!
             entry: resolve(__dirname, 'src/index.ts'),
         },
     },


### PR DESCRIPTION
I'm using this on an ancient codebase using CommonJS. I think this should still install the ESM build on codebases that use ESM.